### PR TITLE
Doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ issue trackers are expected to follow the [Code of Conduct][].
 
 [issues]: https://github.com/greenplum-db/greenplum-db-for-debian/issues
 [pull requests]: https://github.com/greenplum-db/greenplum-db-for-debian/pulls
-[Code of Conduct]: CODE-OF-CONDUCT.MD
+[Code of Conduct]: CODE-OF-CONDUCT.md


### PR DESCRIPTION
Here are a few updates that helped me acclimate with the GP DB for Debian build environment. The most crucial change is quoting the "EOF" in the heredoc section. The quoting suppresses variable substitution which results in an ill-formated file.